### PR TITLE
alsa: make sure to free pcm params in destructor

### DIFF
--- a/src/audio/ao_alsa.h
+++ b/src/audio/ao_alsa.h
@@ -37,9 +37,7 @@ class AudioOutALSA : public AudioOutBase
     snd_pcm_sframes_t frames_to_deliver;
     snd_pcm_uframes_t frames;
     unsigned int periods;
-    int nfds;
     int err;
-    struct pollfd *pfds;
     QByteArray m_buffer;
 
     static void *playSound(void *self);


### PR DESCRIPTION
Use the RAII to make sure to memory blocks are freed in ALSA output.
Not a very important issue, but it's next episode in the AddressSanitizer adventure.

There is some more which pollutes my log, but they may be internal to Qt so it's not sure if I can do anything about it.