### PR TITLE
bank editor: lazy adjustment of size and layout update

### DIFF
--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -86,7 +86,6 @@ BankEditor::BankEditor(QWidget *parent) :
     #else
     this->setWindowFlags(this->windowFlags() & ~Qt::WindowMaximizeButtonHint);
     #endif
-    this->setFixedSize(this->window()->width(), this->window()->height());
     m_importer = new Importer(this);
     m_measurer = new Measurer(this);
     connect(ui->actionImport, SIGNAL(triggered()), m_importer, SLOT(show()));
@@ -182,6 +181,16 @@ void BankEditor::dropEvent(QDropEvent *e)
     }
 }
 
+void BankEditor::showEvent(QShowEvent *event)
+{
+    QMainWindow::showEvent(event);
+    QTimer::singleShot(0, this, SLOT(onBankEditorShown()));
+}
+
+void BankEditor::onBankEditorShown()
+{
+    adjustSize();
+}
 
 void BankEditor::initFileData(QString &filePath)
 {

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -451,12 +451,18 @@ private slots:
 
     void on_velocityOffset_valueChanged(int arg1);
 
+    /**
+     * @brief Adjusts the size of the window after it has been shown
+     */
+    void onBankEditorShown();
+
 protected:
     void closeEvent(QCloseEvent *event);
     void dragEnterEvent(QDragEnterEvent *e);
     void dropEvent(QDropEvent *e);
     virtual void keyPressEvent(QKeyEvent *event);
     virtual void keyReleaseEvent(QKeyEvent *event);
+    void showEvent(QShowEvent *event);
 
 private:
     Ui::BankEditor *ui;

--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1058</width>
-    <height>759</height>
+    <width>1115</width>
+    <height>805</height>
    </rect>
   </property>
   <property name="focusPolicy">
@@ -28,21 +28,6 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout_14">
-    <property name="spacing">
-     <number>0</number>
-    </property>
-    <property name="leftMargin">
-     <number>2</number>
-    </property>
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <property name="rightMargin">
-     <number>2</number>
-    </property>
-    <property name="bottomMargin">
-     <number>0</number>
-    </property>
     <item>
      <widget class="QFrame" name="frame_4">
       <property name="sizePolicy">
@@ -178,16 +163,16 @@
                </property>
                <layout class="QHBoxLayout" name="horizontalLayout_15">
                 <property name="leftMargin">
-                 <number>0</number>
+                 <number>2</number>
                 </property>
                 <property name="topMargin">
-                 <number>1</number>
+                 <number>4</number>
                 </property>
                 <property name="rightMargin">
-                 <number>0</number>
+                 <number>2</number>
                 </property>
                 <property name="bottomMargin">
-                 <number>1</number>
+                 <number>4</number>
                 </property>
                 <item>
                  <widget class="QLabel" name="label_41">
@@ -368,13 +353,13 @@
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_3">
                 <property name="leftMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="topMargin">
                  <number>0</number>
                 </property>
                 <property name="rightMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="bottomMargin">
                  <number>0</number>
@@ -800,13 +785,13 @@
                </property>
                <layout class="QHBoxLayout" name="horizontalLayout_14">
                 <property name="leftMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="topMargin">
                  <number>1</number>
                 </property>
                 <property name="rightMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="bottomMargin">
                  <number>1</number>
@@ -1051,13 +1036,13 @@
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_2">
                 <property name="leftMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="topMargin">
                  <number>0</number>
                 </property>
                 <property name="rightMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="bottomMargin">
                  <number>0</number>
@@ -1482,13 +1467,13 @@
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_4">
                 <property name="leftMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="topMargin">
                  <number>0</number>
                 </property>
                 <property name="rightMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="bottomMargin">
                  <number>0</number>
@@ -1898,13 +1883,13 @@
                </property>
                <layout class="QVBoxLayout" name="verticalLayout">
                 <property name="leftMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="topMargin">
                  <number>0</number>
                 </property>
                 <property name="rightMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="bottomMargin">
                  <number>0</number>
@@ -2373,13 +2358,13 @@
                </property>
                <layout class="QHBoxLayout" name="horizontalLayout_10">
                 <property name="leftMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="topMargin">
                  <number>1</number>
                 </property>
                 <property name="rightMargin">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="bottomMargin">
                  <number>1</number>
@@ -2648,13 +2633,13 @@
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_7">
              <property name="leftMargin">
-              <number>0</number>
+              <number>1</number>
              </property>
              <property name="topMargin">
               <number>0</number>
              </property>
              <property name="rightMargin">
-              <number>0</number>
+              <number>1</number>
              </property>
              <property name="bottomMargin">
               <number>0</number>
@@ -2720,13 +2705,13 @@
               <number>2</number>
              </property>
              <property name="leftMargin">
-              <number>0</number>
+              <number>1</number>
              </property>
              <property name="topMargin">
               <number>0</number>
              </property>
              <property name="rightMargin">
-              <number>0</number>
+              <number>1</number>
              </property>
              <property name="bottomMargin">
               <number>0</number>
@@ -2779,13 +2764,13 @@
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_9">
              <property name="leftMargin">
-              <number>0</number>
+              <number>1</number>
              </property>
              <property name="topMargin">
               <number>0</number>
              </property>
              <property name="rightMargin">
-              <number>0</number>
+              <number>1</number>
              </property>
              <property name="bottomMargin">
               <number>0</number>
@@ -3110,8 +3095,8 @@ of second voice</string>
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1058</width>
-     <height>20</height>
+     <width>1115</width>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,6 @@ int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
     BankEditor w;
-    w.adjustSize();
     w.show();
 
     QStringList args = a.arguments();


### PR DESCRIPTION
Based on @papiezak's feedback on Windows UI, I add a fix and some changes.

I remove a `setFixedSize` call in the main window. It would potentially supersede the automatic adjument of size I have attempted to make, and window would stay in the size defined in the designer file.
(please note now, the window has become resizable by size grip)
Second, I am postponing the adjustment of size at the latest time after the window is shown. It is the best way to ensure everything is set up and well before setting the final size.

Based on the screencap of the Windows version, I have added some margins where I found them appropriate. This time signals-slots are still present and not deleted for whatever reason.

I tried this under Wine. (since this OS has the smallest gui elements, it may have opportunities to pack things a bit more compactly. you judge)
![bankeditorwin](https://user-images.githubusercontent.com/17614485/39624185-a3e36c58-4f98-11e8-9ca3-a6a25e057f2b.png)