### PR TITLE
allow the instrument list to take keyboard focus

### DIFF
--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -277,9 +277,6 @@
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
-               <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
-               </property>
               </widget>
              </item>
             </layout>


### PR DESCRIPTION
It allows to navigate the instrument list with the keyboard only.
I couldn't think of reasons why this widget was excluded from keyboard focus, when all the other edit widgets were permitted to have it.