### PR TITLE
Midi

### DIFF
--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -2755,7 +2755,7 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>40</width>
+                 <width>10</width>
                  <height>20</height>
                 </size>
                </property>
@@ -2795,7 +2795,7 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>40</width>
+                 <width>10</width>
                  <height>20</height>
                 </size>
                </property>

--- a/src/midi/midi_rtmidi.cpp
+++ b/src/midi/midi_rtmidi.cpp
@@ -41,7 +41,7 @@ bool MidiInRt::open(unsigned port)
     RtMidiIn *midiin = lazyInstance();
     m_midiin->closePort();
     m_errorSignaled = false;
-    midiin->openPort(port, "MIDI input");
+    midiin->openPort(port, defaultPortName().toStdString());
     return !m_errorSignaled;
 }
 
@@ -50,7 +50,7 @@ bool MidiInRt::openVirtual()
     RtMidiIn *midiin = lazyInstance();
     m_midiin->closePort();
     m_errorSignaled = false;
-    midiin->openVirtualPort("MIDI input");
+    midiin->openVirtualPort(defaultPortName().toStdString());
     return !m_errorSignaled;
 }
 
@@ -88,13 +88,22 @@ bool MidiInRt::getPortList(QVector<QString> &ports)
     return true;
 }
 
+QString MidiInRt::defaultClientName()
+{
+    return QCoreApplication::applicationName();
+}
+QString MidiInRt::defaultPortName()
+{
+    return QCoreApplication::applicationName() + " MIDI input";
+}
+
 RtMidiIn *MidiInRt::lazyInstance()
 {
     RtMidiIn *midiin = m_midiin;
     if(!midiin) {
-        const QString &name = QCoreApplication::applicationName();
         unsigned bufferSize = 1024;
-        midiin = m_midiin = new RtMidiIn(RtMidi::UNSPECIFIED, name.toStdString(), bufferSize);
+        midiin = m_midiin = new RtMidiIn(
+            RtMidi::UNSPECIFIED, defaultClientName().toStdString(), bufferSize);
         midiin->setCallback(&onReceive, this);
         midiin->setErrorCallback(&onError, this);
     }

--- a/src/midi/midi_rtmidi.h
+++ b/src/midi/midi_rtmidi.h
@@ -38,6 +38,9 @@ public:
     bool canOpenVirtual();
     bool getPortList(QVector<QString> &ports);
 
+    static QString defaultClientName();
+    static QString defaultPortName();
+
     const QString &getErrorText() const
     {
         return m_errorText;


### PR DESCRIPTION
- resizes horizontal spacers to smaller sizes (need someone's feedback who has the size problem on Windows)
- rename MIDI ports such that the application name will be shown