### PR TITLE
Ctrl-S quick save

### DIFF
--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -165,16 +165,17 @@ public:
     bool saveBankFile(QString filePath, BankFormats format);
     /*!
      * \brief Save current instrument file
-     * \param filePath absolute path where save a file
+     * \param filePath absolute path where to save a file
      * \param format Target format to save a file
      * \return true if file successfully saved, false if failed
      */
     bool saveInstrumentFile(QString filePath, InstFormats format);
     /*!
-     * \brief Open Save-As dialog box
+     * \brief Saves current bank file, asking for file path if necessary
+     * \param optionalFilePath absolute path where to save a file, or empty string
      * \return true if file successfuly saved, false on rejecting or on fail
      */
-    bool saveFileAs();
+    bool saveFileAs(const QString &optionalFilePath = QString());
     /*!
      * \brief Open Save-As dialog box for single instrument
      * \return true if file successfuly saved, false on rejecting or on fail
@@ -223,6 +224,16 @@ public:
 
     void reloadBanks();
 
+private:
+    /**
+     * Path of the file which is currently edited
+     */
+    QString m_currentFilePath;
+    /**
+     * Format of the file which is currently edited
+     */
+    BankFormats m_currentFileFormat;
+
 public slots:
     /**
      * @brief Toggle melodic mode and fill instruments list with melodic instruments names
@@ -262,9 +273,13 @@ private slots:
      */
     void on_actionOpen_triggered();
     /**
-     * @brief Save current bank state into the file
+     * @brief Save current bank state into the current file
      */
     void on_actionSave_triggered();
+    /**
+     * @brief Save current bank state into a selected file
+     */
+    void on_actionSaveAs_triggered();
     /**
      * @brief Save current instrument into the file
      */

--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -3289,6 +3289,7 @@ of second voice</string>
     <addaction name="actionImport"/>
     <addaction name="actionOpen"/>
     <addaction name="actionSave"/>
+    <addaction name="actionSaveAs"/>
     <addaction name="actionSaveInstrument"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
@@ -3362,12 +3363,9 @@ of second voice</string>
     <string notr="true">Ctrl+O</string>
    </property>
   </action>
-  <action name="actionSave">
+  <action name="actionSaveAs">
    <property name="text">
     <string>Save bank as...</string>
-   </property>
-   <property name="shortcut">
-    <string notr="true">Ctrl+S</string>
    </property>
   </action>
   <action name="actionExit">
@@ -3531,6 +3529,14 @@ of second voice</string>
   <action name="actionChipsBenchmark">
    <property name="text">
     <string>Run emulators benchmark</string>
+   </property>
+  </action>
+  <action name="actionSave">
+   <property name="text">
+    <string>Save bank...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
The bank editor will keep track of the path name which is displayed in the title label.
Ctrl+S is reassigned to "Save" instead of "Save As".
Depending on action, the new `saveFileAs` function signature is invoked with either file path, or empty string. In the former case, and when a file is current in the editor, the dialog box selection is skipped and the current file name is used.