### PR TITLE
give the audio client the appropriate name

### DIFF
--- a/src/audio/ao_rtaudio.cpp
+++ b/src/audio/ao_rtaudio.cpp
@@ -54,7 +54,7 @@ AudioOutRt::AudioOutRt(double latency, QObject *parent)
 
     RtAudio::StreamOptions streamOpts;
     streamOpts.flags = RTAUDIO_ALSA_USE_DEFAULT;
-    streamOpts.streamName = "ADLrt";
+    streamOpts.streamName = QCoreApplication::applicationName().toStdString();
 
     unsigned bufferSize = std::ceil(latency * sampleRate);
     qDebug() << "Desired latency" << latency;


### PR DESCRIPTION
Forgot to change client name after copying code out of ADLrt.
Better now:

![client](https://user-images.githubusercontent.com/17614485/39970383-948cf46e-56ea-11e8-91b8-95c15e9df984.png)
