### PR TITLE
undo a std::string copy where not needed

### DIFF
--- a/src/midi/midi_rtmidi.cpp
+++ b/src/midi/midi_rtmidi.cpp
@@ -97,7 +97,7 @@ bool MidiInRt::getPortList(QVector<QString> &ports)
             std::string name = midiin->getPortName(i);
             if(m_errorSignaled)
                 return false;
-            ports[i] = QString::fromStdString(name.c_str());
+            ports[i] = QString::fromStdString(name);
         }
     }
     return true;


### PR DESCRIPTION
It's a small thing I caught when making the diff with OPN2 sources.