### PR TITLE
implement MIDI features: pitch bend, (N)RPN tracking, bend sensitivity, hold pedal

### DIFF
--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -110,6 +110,8 @@ BankEditor::BankEditor(QWidget *parent) :
 
     ui->instruments->installEventFilter(this);
 
+    ui->pitchBendSlider->setTracking(true);
+
     connect(ui->actionLanguageDefault, SIGNAL(triggered()), this, SLOT(onActionLanguageTriggered()));
 
     loadSettings();

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -508,6 +508,8 @@ private slots:
     void on_pitchBendSlider_valueChanged(int value);
     void on_pitchBendSlider_sliderReleased();
 
+    void on_holdButton_toggled(bool checked);
+
     /**
      * @brief Adjusts the size of the window after it has been shown
      */

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -505,6 +505,9 @@ private slots:
 
     void on_velocityOffset_valueChanged(int arg1);
 
+    void on_pitchBendSlider_valueChanged(int value);
+    void on_pitchBendSlider_sliderReleased();
+
     /**
      * @brief Adjusts the size of the window after it has been shown
      */

--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -3242,32 +3242,58 @@ of second voice</string>
      </widget>
     </item>
     <item>
-     <widget class="Piano" name="piano">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>75</height>
-       </size>
-      </property>
-      <property name="autoFillBackground">
-       <bool>false</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
-      </property>
-      <property name="frameShadow">
-       <enum>QFrame::Sunken</enum>
-      </property>
-     </widget>
+     <layout class="QHBoxLayout" name="horizontalLayout_18">
+      <item>
+       <widget class="QSlider" name="pitchBendSlider">
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Pitch bend</string>
+        </property>
+        <property name="minimum">
+         <number>-100</number>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBothSides</enum>
+        </property>
+        <property name="tickInterval">
+         <number>50</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Piano" name="piano">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>75</height>
+         </size>
+        </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">background-color: rgb(255, 255, 255);</string>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Sunken</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -27,7 +27,7 @@
     <normaloff>:/icons/opl3_16.png</normaloff>:/icons/opl3_16.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout_14">
+   <layout class="QVBoxLayout" name="verticalLayout_15">
     <item>
      <widget class="QFrame" name="frame_4">
       <property name="sizePolicy">
@@ -3242,7 +3242,109 @@ of second voice</string>
      </widget>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_18">
+     <layout class="QHBoxLayout" name="horizontalLayout_20">
+      <property name="spacing">
+       <number>1</number>
+      </property>
+      <item>
+       <widget class="QFrame" name="frame_5">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_14">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <spacer name="verticalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_18">
+           <property name="spacing">
+            <number>1</number>
+           </property>
+           <item>
+            <spacer name="horizontalSpacer_12">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>1</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QToolButton" name="holdButton">
+             <property name="toolTip">
+              <string>Hold</string>
+             </property>
+             <property name="text">
+              <string>H</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_13">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>1</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item>
        <widget class="QSlider" name="pitchBendSlider">
         <property name="focusPolicy">
@@ -3268,7 +3370,7 @@ of second voice</string>
       <item>
        <widget class="Piano" name="piano">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>

--- a/src/controlls.cpp
+++ b/src/controlls.cpp
@@ -18,7 +18,7 @@
 
 #include "bank_editor.h"
 #include "ui_bank_editor.h"
-
+#include <cmath>
 
 void BankEditor::on_insName_textChanged(const QString &arg1)
 {
@@ -184,6 +184,16 @@ void BankEditor::on_velocityOffset_valueChanged(int arg1)
     sendPatch();
 }
 
+void BankEditor::on_pitchBendSlider_valueChanged(int value)
+{
+    int bend = (int)std::lround(value * (8192.0 / 100.0));
+    m_generator->ctl_pitchBend(bend);
+}
+
+void BankEditor::on_pitchBendSlider_sliderReleased()
+{
+    ui->pitchBendSlider->setValue(0);  // spring back to middle position
+}
 
 
 /* ***************** Modulator 1 ***************** */

--- a/src/controlls.cpp
+++ b/src/controlls.cpp
@@ -195,6 +195,10 @@ void BankEditor::on_pitchBendSlider_sliderReleased()
     ui->pitchBendSlider->setValue(0);  // spring back to middle position
 }
 
+void BankEditor::on_holdButton_toggled(bool checked)
+{
+    m_generator->ctl_hold(checked);
+}
 
 /* ***************** Modulator 1 ***************** */
 

--- a/src/opl/generator.cpp
+++ b/src/opl/generator.cpp
@@ -736,6 +736,8 @@ void Generator::changePatch(const FmBank::Instrument &instrument, bool isDrum)
 {
     //Shutup everything
     Silence();
+    m_bend = 0.0;
+    m_bendsense = 2.0 / 8192;
     switch4op(instrument.en_4op && !instrument.en_pseudo4op && (instrument.adlib_drum_number == 0));
     bool isAdLibDrums = isDrum && (instrument.adlib_drum_number > 0);
     changeAdLibPercussion(isAdLibDrums);

--- a/src/opl/generator.cpp
+++ b/src/opl/generator.cpp
@@ -732,6 +732,11 @@ void Generator::PitchBend(int bend)
     }
 }
 
+void Generator::PitchBendSensitivity(int cents)
+{
+    m_bendsense = cents * (1e-2 / 8192);
+}
+
 void Generator::changePatch(const FmBank::Instrument &instrument, bool isDrum)
 {
     //Shutup everything

--- a/src/opl/generator.h
+++ b/src/opl/generator.h
@@ -92,6 +92,7 @@ public:
     void Patch(uint32_t c, uint32_t i);
     void Pan(uint32_t c, uint32_t value);
     void PlayNoteF(int noteID);
+    void PlayNoteCh(int channelID);
     void StopNoteF(int noteID);
     void PlayDrum(uint8_t drum, int noteID);
     void switch4op(bool enabled, bool patchCleanUp = true);
@@ -108,6 +109,7 @@ public:
     void PlayMajor7Chord();
     void PlayMinor7Chord();
     void StopNote();
+    void PitchBend(int bend);
 
     void changePatch(const FmBank::Instrument &instrument, bool isDrum = false);
     void changeNote(int newnote);
@@ -127,6 +129,7 @@ private:
 
     class NotesManager
     {
+    public:
         struct Note
         {
             //! Currently pressed key. -1 means channel is free
@@ -134,6 +137,7 @@ private:
             //! Age in count of noteOn requests
             int age = 0;
         };
+    private:
         //! Channels range, contains entries count equal to chip channels
         QVector<Note> channels;
         //! Round-Robin cycler. Looks for any free channel that is not busy. Otherwise, oldest busy note will be replaced
@@ -145,9 +149,15 @@ private:
         uint8_t noteOn(int note);
         int8_t  noteOff(int note);
         void clearNotes();
+        const Note &channel(int ch) const
+            { return channels.at(ch); }
+        const int channelCount() const
+            { return (int)channels.size(); }
     } m_noteManager;
 
     int32_t     note;
+    double      m_bend = 0.0;
+    double      m_bendsense = 2.0 / 8192;
     bool        m_isInstrumentLoaded = false;
     bool        m_4op_last_state;
     uint8_t     deepTremoloMode;

--- a/src/opl/generator.h
+++ b/src/opl/generator.h
@@ -94,6 +94,7 @@ public:
     void PlayNoteF(int noteID);
     void PlayNoteCh(int channelID);
     void StopNoteF(int noteID);
+    void StopNoteCh(int channelID);
     void PlayDrum(uint8_t drum, int noteID);
     void switch4op(bool enabled, bool patchCleanUp = true);
 
@@ -111,6 +112,7 @@ public:
     void StopNote();
     void PitchBend(int bend);
     void PitchBendSensitivity(int cents);
+    void Hold(bool held);
 
     void changePatch(const FmBank::Instrument &instrument, bool isDrum = false);
     void changeNote(int newnote);
@@ -137,6 +139,8 @@ private:
             int note    = -1;
             //! Age in count of noteOn requests
             int age = 0;
+            //! Whether it has a pending noteOff being delayed while held
+            bool held = false;
         };
     private:
         //! Channels range, contains entries count equal to chip channels
@@ -149,6 +153,9 @@ private:
         void allocateChannels(int count);
         uint8_t noteOn(int note);
         int8_t  noteOff(int note);
+        void    channelOff(int ch);
+        int8_t  findNoteOffChannel(int note);
+        void hold(int ch, bool h);
         void clearNotes();
         const Note &channel(int ch) const
             { return channels.at(ch); }
@@ -159,6 +166,7 @@ private:
     int32_t     note;
     double      m_bend = 0.0;
     double      m_bendsense = 2.0 / 8192;
+    bool        m_hold = false;
     bool        m_isInstrumentLoaded = false;
     bool        m_4op_last_state;
     uint8_t     deepTremoloMode;

--- a/src/opl/generator.h
+++ b/src/opl/generator.h
@@ -110,6 +110,7 @@ public:
     void PlayMinor7Chord();
     void StopNote();
     void PitchBend(int bend);
+    void PitchBendSensitivity(int cents);
 
     void changePatch(const FmBank::Instrument &instrument, bool isDrum = false);
     void changeNote(int newnote);

--- a/src/opl/generator.h
+++ b/src/opl/generator.h
@@ -151,7 +151,7 @@ private:
         NotesManager();
         ~NotesManager();
         void allocateChannels(int count);
-        uint8_t noteOn(int note);
+        uint8_t noteOn(int note, bool *replace = nullptr);
         int8_t  noteOff(int note);
         void    channelOff(int ch);
         int8_t  findNoteOffChannel(int note);

--- a/src/opl/generator_realtime.cpp
+++ b/src/opl/generator_realtime.cpp
@@ -28,6 +28,7 @@ enum MessageTag
     MSG_CtlNoteOffAllChans,
     MSG_CtlPlayNote,
     MSG_CtlStopNote,
+    MSG_CtlPitchBend,
     MSG_CtlPlayChord,
     MSG_CtlPatchChange,
     MSG_CtlDeepVibrato,
@@ -141,6 +142,15 @@ void RealtimeGenerator::ctl_stopNote()
     wait_for_fifo_write_space(rb, hdr.size);
     rb.put(hdr);
     rb.put(m_note);
+}
+
+void RealtimeGenerator::ctl_pitchBend(int bend)
+{
+    Ring_Buffer &rb = *m_rb_ctl;
+    MessageHeader hdr = {MSG_CtlPitchBend, sizeof(int)};
+    wait_for_fifo_write_space(rb, hdr.size);
+    rb.put(hdr);
+    rb.put(bend);
 }
 
 void RealtimeGenerator::ctl_playChord(int chord)
@@ -267,6 +277,9 @@ void RealtimeGenerator::rt_message_process(int tag, const uint8_t *data, unsigne
     case MSG_CtlStopNote:
         gen.changeNote(*(unsigned *)data);
         gen.StopNote();
+        break;
+    case MSG_CtlPitchBend:
+        gen.PitchBend(*(int *)data);
         break;
     case MSG_CtlPlayChord: {
         ChordMessage msg = *(ChordMessage *)data;

--- a/src/opl/generator_realtime.cpp
+++ b/src/opl/generator_realtime.cpp
@@ -323,6 +323,9 @@ void RealtimeGenerator::rt_midi_process(const uint8_t *data, unsigned len)
             if (note == 123)  // all notes off
                 gen.NoteOffAllChans();
             break;
+        case 0xe:
+            gen.PitchBend((int)((vel << 7) | note) - 8192);
+            break;
         }
     }
 }

--- a/src/opl/generator_realtime.h
+++ b/src/opl/generator_realtime.h
@@ -54,6 +54,7 @@ public slots:
     virtual void ctl_noteOffAllChans() = 0;
     virtual void ctl_playNote() = 0;
     virtual void ctl_stopNote() = 0;
+    virtual void ctl_pitchBend(int bend) = 0;
 
     virtual void ctl_playChord(int chord) = 0;
     void ctl_playMajorChord();
@@ -119,6 +120,7 @@ public:
     void ctl_noteOffAllChans() override;
     void ctl_playNote() override;
     void ctl_stopNote() override;
+    void ctl_pitchBend(int bend) override;
     void ctl_playChord(int chord) override;
     void ctl_changePatch(FmBank::Instrument &instrument, bool isDrum = false) override;
     void ctl_changeDeepVibrato(bool enabled) override;

--- a/src/opl/generator_realtime.h
+++ b/src/opl/generator_realtime.h
@@ -55,6 +55,7 @@ public slots:
     virtual void ctl_playNote() = 0;
     virtual void ctl_stopNote() = 0;
     virtual void ctl_pitchBend(int bend) = 0;
+    virtual void ctl_hold(bool held) = 0;
 
     virtual void ctl_playChord(int chord) = 0;
     void ctl_playMajorChord();
@@ -121,6 +122,7 @@ public:
     void ctl_playNote() override;
     void ctl_stopNote() override;
     void ctl_pitchBend(int bend) override;
+    void ctl_hold(bool held) override;
     void ctl_playChord(int chord) override;
     void ctl_changePatch(FmBank::Instrument &instrument, bool isDrum = false) override;
     void ctl_changeDeepVibrato(bool enabled) override;

--- a/src/opl/generator_realtime.h
+++ b/src/opl/generator_realtime.h
@@ -143,6 +143,16 @@ private:
     std::unique_ptr<Ring_Buffer> m_rb_midi;
     std::unique_ptr<uint8_t[]> m_body;
 
+    struct MidiChannelInfo
+    {
+        unsigned lastmrpn = 0;
+        unsigned lastlrpn = 0;
+        bool nrpn = false;
+        unsigned bendsensemsb = 2;
+        unsigned bendsenselsb = 0;
+    };
+    MidiChannelInfo m_midichan[16];
+
 #if defined(ENABLE_WIN9X_OPL_PROXY)
     class QStdMutex
     {


### PR DESCRIPTION
#19 

I implement pitch bend functionality.
On a bend event, I update the bend value, go over the active channels and I invoke the same code as `PlayNoteF` as previously to update frequency registers.  
Except now I split that relevant part into a function `PlayNoteCh` which applies to an existing channel number.

No support for RPN in this commit