### PR TITLE
cmake: install desktop files and icons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,17 @@ add_custom_target(OPL3BankEditor_translations ALL
 install(FILES ${TRANSLATIONS}
   DESTINATION "share/opl3_bank_editor/translations")
 
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND
+    NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  install(FILES "src/resources/opl3_bank_editor.desktop"
+    DESTINATION "share/applications")
+  foreach(size 16;32;48)
+    install(FILES "src/resources/opl3_${size}.png"
+      DESTINATION "share/icons/hicolor/${size}x${size}/apps"
+      RENAME "opl3_bank_editor.png")
+  endforeach()
+endif()
+
 add_executable(OPL3BankEditor WIN32 MACOSX_BUNDLE
   ${SOURCES} ${FORMS} ${RESOURCES})
 set_target_properties(OPL3BankEditor PROPERTIES

--- a/src/resources/opl3_bank_editor.desktop
+++ b/src/resources/opl3_bank_editor.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
-Version=1.5
+Version=1.0
 Name=OPL3 Bank Editor
 Name[fr]=Éditeur de banque OPL3
 Name[ru]=Редактор банков OPL3
 Comment=Edit OPL3 FM banks
 Comment[fr]=Édite les banques FM OPL3
 Comment[ru]=Редактор FM-банков для OPL3
-Icon=opl3_48.png
+Icon=opl3_bank_editor
 Exec=opl3_bank_editor
 Categories=AudioVideo;Audio
 Type=Application


### PR DESCRIPTION
Installs the desktop file and the icons of all sizes in the `hicolor` theme.
(on the non-Windows non-Mac systems)

It needs an update of icon cache to recognize.
`sudo gtk-update-icon-cache -f /usr/share/icons/hicolor`