### PR TITLE
add @Wohlstand's proxy style to fix QComboBox width

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SOURCES
   "src/bank_editor.cpp"
   "src/common.cpp"
   "src/controlls.cpp"
+  "src/proxystyle.cpp"
   "src/FileFormats/ffmt_base.cpp"
   "src/FileFormats/ffmt_factory.cpp"
   "src/FileFormats/format_adlib_bnk.cpp"

--- a/FMBankEdit.pro
+++ b/FMBankEdit.pro
@@ -102,6 +102,7 @@ SOURCES += \
     src/bank_editor.cpp \
     src/common.cpp \
     src/controlls.cpp \
+    src/proxystyle.cpp \
     src/FileFormats/ffmt_base.cpp \
     src/FileFormats/ffmt_factory.cpp \
     src/FileFormats/format_adlib_bnk.cpp \
@@ -139,6 +140,7 @@ HEADERS += \
     src/bank_editor.h \
     src/bank.h \
     src/common.h \
+    src/proxystyle.h \
     src/FileFormats/ffmt_base.h \
     src/FileFormats/ffmt_enums.h \
     src/FileFormats/ffmt_factory.h \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 
 #include "main.h"
 #include "bank_editor.h"
+#include "proxystyle.h"
 #include <QLibraryInfo>
 #include <QStringList>
 #include <QDebug>
@@ -27,6 +28,10 @@
 int main(int argc, char *argv[])
 {
     Application a(argc, argv);
+
+#if !defined(IS_QT_4)
+    a.setStyle(new BankEditor_ProxyStyle(a.style()));
+#endif
 
     BankEditor w;
     w.show();

--- a/src/proxystyle.cpp
+++ b/src/proxystyle.cpp
@@ -1,0 +1,102 @@
+/*
+ * OPL Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined(IS_QT_4)
+
+#include <QDockWidget>
+#include <QAbstractItemView>
+#include <QComboBox>
+
+#include "proxystyle.h"
+
+BankEditor_ProxyStyle::BankEditor_ProxyStyle(QStyle *style) : QProxyStyle(style) {}
+
+BankEditor_ProxyStyle::BankEditor_ProxyStyle(const QString &key) : QProxyStyle(key) {}
+
+int BankEditor_ProxyStyle::styleHint(QStyle::StyleHint hint, const QStyleOption *option, const QWidget *widget, QStyleHintReturn *returnData) const
+{
+    switch(hint)
+    {
+        //Combobox fix by Guilherme Nascimento:
+        //http://stackoverflow.com/questions/20554940/qcombobox-pop-up-expanding-and-qtwebkit
+        case QStyle::SH_ComboBox_Popup:
+        {
+            const QComboBox *combo = (QComboBox *) widget;//convert qwidget in QComboBox
+            const QObjectList a = combo->children();
+            const int j = a.count();
+            QAbstractItemView *view = 0;
+            QString className = "";
+            bool hasView = false;
+
+            /*
+                at this point I have not used combo->view() because he "crash" the application without explanation
+                so I had to make a loop to find the "view"
+                */
+            for(int i = 0; i < j; ++i)
+            {
+                const QObjectList b = a.at(i)->children();
+                const int y = b.count();
+
+                for(int x = 0; x < y; ++x)
+                {
+                    className = b.at(x)->metaObject()->className();
+                    if(className == "QComboBoxListView") {
+                        view = (QAbstractItemView *) b.at(x);
+                        hasView = true;
+                        break;
+                    }
+                }
+
+                if (hasView == true)
+                {
+                    break;
+                }
+            }
+
+            if(hasView == true)
+            {
+                const int iconSize = combo->iconSize().width();
+                const QFontMetrics fontMetrics1 = view->fontMetrics();
+                const QFontMetrics fontMetrics2 = combo->fontMetrics();
+                const int j = combo->count();
+                int width = combo->width(); //default width
+
+                for(int i=0; i < j; ++i)
+                {
+                    const int textWidth = qMax(
+                                fontMetrics1.width(combo->itemText(i) + "WW"),
+                                fontMetrics2.width(combo->itemText(i) + "WW")
+                                );
+                    if(combo->itemIcon(i).isNull())
+                        width = qMax(width, textWidth);
+                    else
+                        width = qMax(width, textWidth + iconSize);
+                }
+
+                view->setFixedWidth(width);
+            }
+        } /*fallthrough*/
+        //Combobox fix end
+
+        default:
+            break;
+    }
+    return QProxyStyle::styleHint(hint, option, widget, returnData);
+}
+
+#endif  // !defined(IS_QT_4)

--- a/src/proxystyle.h
+++ b/src/proxystyle.h
@@ -1,0 +1,39 @@
+/*
+ * OPL Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#ifndef PROXYSTYLE_H
+#define PROXYSTYLE_H
+
+#if !defined(IS_QT_4)
+
+#include <QProxyStyle>
+
+class QWidget;
+class BankEditor_ProxyStyle : public QProxyStyle
+{
+public:
+    explicit BankEditor_ProxyStyle(QStyle *style = Q_NULLPTR);
+    explicit BankEditor_ProxyStyle(const QString &key);
+
+    int styleHint(StyleHint hint, const QStyleOption *option, const QWidget *widget, QStyleHintReturn *returnData) const;
+};
+
+#endif  // !defined(IS_QT_4)
+
+#endif // PROXYSTYLE_H


### PR DESCRIPTION
#88 

Proxy style from PGE editor.
May fix Windows combo box width problems. Not compatible with Qt4. To test.
