### PR TITLE
fix typo in WOPL file comments

### DIFF
--- a/src/FileFormats/wopl/wopl_file.h
+++ b/src/FileFormats/wopl/wopl_file.h
@@ -242,7 +242,7 @@ extern WOPLFile *WOPL_LoadBankFromMem(void *mem, size_t length, int *error);
 /**
  * @brief Load WOPI instrument file from the memory.
  * You must allocate WOPIFile structure by yourself and give the pointer to it.
- * @param file Pointer to destinition WOPIFile structure to fill it with parsed data.
+ * @param file Pointer to destination WOPIFile structure to fill it with parsed data.
  * @param mem Pointer to memory block contains raw WOPI instrument file data
  * @param length Length of given memory block
  * @return 0 if no errors occouped, or an error code of WOPL_ErrorCodes enumeration
@@ -252,7 +252,7 @@ extern int WOPL_LoadInstFromMem(WOPIFile *file, void *mem, size_t length);
 /**
  * @brief Calculate the size of the output memory block
  * @param file Heap-allocated WOPL file data structure
- * @param version Destinition version of the file
+ * @param version Destination version of the file
  * @return Size of the raw WOPL file data
  */
 extern size_t WOPL_CalculateBankFileSize(WOPLFile *file, uint16_t version);
@@ -260,7 +260,7 @@ extern size_t WOPL_CalculateBankFileSize(WOPLFile *file, uint16_t version);
 /**
  * @brief Calculate the size of the output memory block
  * @param file Pointer to WOPI file data structure
- * @param version Destinition version of the file
+ * @param version Destination version of the file
  * @return Size of the raw WOPI file data
  */
 extern size_t WOPL_CalculateInstFileSize(WOPIFile *file, uint16_t version);
@@ -268,8 +268,8 @@ extern size_t WOPL_CalculateInstFileSize(WOPIFile *file, uint16_t version);
 /**
  * @brief Write raw WOPL into given memory block
  * @param file Heap-allocated WOPL file data structure
- * @param dest_mem Destinition memory block pointer
- * @param length Length of destinition memory block
+ * @param dest_mem Destination memory block pointer
+ * @param length Length of destination memory block
  * @param version Wanted WOPL version
  * @param force_gm Force GM set in saved bank file
  * @return Error code or 0 on success
@@ -279,8 +279,8 @@ extern int WOPL_SaveBankToMem(WOPLFile *file, void *dest_mem, size_t length, uin
 /**
  * @brief Write raw WOPI into given memory block
  * @param file Pointer to WOPI file data structure
- * @param dest_mem Destinition memory block pointer
- * @param length Length of destinition memory block
+ * @param dest_mem Destination memory block pointer
+ * @param length Length of destination memory block
  * @param version Wanted WOPI version
  * @return Error code or 0 on success
  */


### PR DESCRIPTION
Fixes a recurrent typo in `wopl_file.h` comments