### PR TITLE
safer detection of libqwt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ include(FindPkgConfig)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Concurrent REQUIRED)
 find_package(Qt5LinguistTools REQUIRED)
+set(QWT_NAMES qwt-qt5 qwt) # find versions for Qt5 only
 find_package(Qwt)
 find_package(Threads REQUIRED)
 
@@ -48,6 +49,10 @@ if(USE_RTAUDIO)
     pkg_check_modules(PULSEAUDIO "libpulse-simple")
     message("!!   -- Pulseaudio driver: ${PULSEAUDIO_FOUND}")
   endif()
+endif()
+
+if(ENABLE_PLOTS)
+  message("!!   Qwt: ${QWT_LIBRARY}")
 endif()
 
 message("!!   Plots: ${ENABLE_PLOTS}")

--- a/cmake/FindQwt.cmake
+++ b/cmake/FindQwt.cmake
@@ -42,11 +42,14 @@
 # either expressed or implied, of the FreeBSD Project.
 #=============================================================================
 
+if ( NOT QWT_NAMES )
+  set ( QWT_NAMES qwt qwt-qt3 qwt-qt4 qwt-qt5 )
+endif ()
 
 find_path ( QWT_INCLUDE_DIR
   NAMES qwt_plot.h
   HINTS ${QT_INCLUDE_DIR}
-  PATH_SUFFIXES qwt qwt-qt3 qwt-qt4 qwt-qt5
+  PATH_SUFFIXES ${QWT_NAMES}
 )
 
 set ( QWT_INCLUDE_DIRS ${QWT_INCLUDE_DIR} )
@@ -80,7 +83,7 @@ endif ()
 
 
 find_library ( QWT_LIBRARY
-  NAMES qwt qwt-qt3 qwt-qt4 qwt-qt5
+  NAMES ${QWT_NAMES}
   HINTS ${QT_LIBRARY_DIR}
 )
 


### PR DESCRIPTION
Proposing a safer way to find Qwt. (but not flawless)
When having Qwt for Qt4 installed, the system may pick up this version and create a OPL3-BE which links to both of Qt4 and Qt5 at the end of the cmake build.
As one can expect, the runtime segfaults sometime early in the startup process.
