### PR TITLE
protect the IMF importer from invalid access

### DIFF
--- a/src/FileFormats/format_imf_importer.cpp
+++ b/src/FileFormats/format_imf_importer.cpp
@@ -58,9 +58,9 @@ bool IMF_Importer::detect(const QString &filePath, char *)
 
 FfmtErrCode IMF_Importer::loadFile(QString filePath, FmBank &bank)
 {
-    uint8_t ymram[0xFF];
+    uint8_t ymram[0x100];
     bool    keys[9];
-    memset(ymram, 0, 0xFF);
+    memset(ymram, 0, 0x100);
     memset(keys, 0, sizeof(bool) * 9);
 
     QSet<QByteArray> cache;


### PR DESCRIPTION
In case it reads the byte `FF`, the array access will be out of bounds.