### PR TITLE
dro: don't pass high registers to chip in OPL2 case

### DIFF
--- a/src/FileFormats/format_dro_importer.cpp
+++ b/src/FileFormats/format_dro_importer.cpp
@@ -247,7 +247,7 @@ FfmtErrCode DRO_Importer::loadFileV2(QFile &file, FmBank &bank)
                 chip[1].passReg(reg, val);
             else if(chipSelect && hardwareType == OplMode3)
                 chip[0].passReg(reg | 0x100u, val);
-            else
+            else if (!chipSelect)
                 chip[0].passReg(reg, val);
         }
     }


### PR DESCRIPTION
I think this fixes the importer problems.
On OPL2 hardware type: just ignore the upper register commands.
