### PR TITLE
fix a crash at startup with hardware OPL enabled

### DIFF
--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -145,6 +145,11 @@ BankEditor::BankEditor(QWidget *parent) :
     m_bankBackup = m_bank;
 
     initAudio();
+
+#ifdef ENABLE_HW_OPL_PROXY
+    initChip();
+#endif
+
 #ifdef ENABLE_MIDI
     QAction *midiInAction = m_midiInAction = new QAction(
         ui->midiIn->icon(), ui->midiIn->text(), this);

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -102,7 +102,7 @@ private:
     bool m_lock;
 
     //! OPL chip emulator frontent
-    IRealtimeControl *m_generator;
+    IRealtimeControl *m_generator = nullptr;
 
     //! Sound length measurer
     Measurer        *m_measurer;


### PR DESCRIPTION
The call `loadSettings()`→`initChip()` accesses `m_generator` before creation.
Initialize `m_generator` with null, and perform the `initChip()` a moment later.