### PR TITLE
add the reader and writer of HSC instruments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(FILEFORMATS_SOURCES
   "src/FileFormats/format_dro_importer.cpp"
   "src/FileFormats/format_misc_sgi.cpp"
   "src/FileFormats/format_misc_cif.cpp"
+  "src/FileFormats/format_misc_hsc.cpp"
   "src/FileFormats/format_wohlstand_opl3.cpp"
   "src/FileFormats/format_flatbuffer_opl3.cpp"
   "src/FileFormats/ymf262_to_wopi.cpp"

--- a/FMBankEdit.pro
+++ b/FMBankEdit.pro
@@ -123,6 +123,7 @@ SOURCES += \
     src/FileFormats/format_dro_importer.cpp \
     src/FileFormats/format_misc_sgi.cpp \
     src/FileFormats/format_misc_cif.cpp \
+    src/FileFormats/format_misc_hsc.cpp \
     src/FileFormats/format_wohlstand_opl3.cpp \
     src/FileFormats/format_flatbuffer_opl3.cpp \
     src/FileFormats/ymf262_to_wopi.cpp \
@@ -168,6 +169,7 @@ HEADERS += \
     src/FileFormats/format_dro_importer.h \
     src/FileFormats/format_misc_sgi.h \
     src/FileFormats/format_misc_cif.h \
+    src/FileFormats/format_misc_hsc.h \
     src/FileFormats/format_wohlstand_opl3.h \
     src/FileFormats/format_flatbuffer_opl3.h \
     src/FileFormats/ymf262_to_wopi.h \

--- a/src/FileFormats/ffmt_enums.h
+++ b/src/FileFormats/ffmt_enums.h
@@ -64,6 +64,7 @@ enum class InstFormats
     FORMAT_INST_ADLIB_INS,
     FORMAT_INST_SGI,
     FORMAT_INST_CIF,
+    FORMAT_INST_HSC,
 };
 
 enum class FormatCaps

--- a/src/FileFormats/ffmt_factory.cpp
+++ b/src/FileFormats/ffmt_factory.cpp
@@ -38,6 +38,7 @@
 #include "format_dro_importer.h"
 #include "format_misc_sgi.h"
 #include "format_misc_cif.h"
+#include "format_misc_hsc.h"
 #include "format_wohlstand_opl3.h"
 #include "format_flatbuffer_opl3.h"
 
@@ -118,6 +119,7 @@ void FmBankFormatFactory::registerAllFormats()
     //Misc
     registerInstFormat(new Misc_SGI());
     registerInstFormat(new Misc_CIF());
+    registerInstFormat(new Misc_HSC());
 }
 
 

--- a/src/FileFormats/format_misc_hsc.cpp
+++ b/src/FileFormats/format_misc_hsc.cpp
@@ -1,0 +1,93 @@
+/*
+ * OPL Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2016-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "format_misc_hsc.h"
+#include "../common.h"
+#include <QFileInfo>
+
+bool Misc_HSC::detectInst(const QString &filePath, char* magic)
+{
+    return filePath.endsWith(".ins", Qt::CaseInsensitive) &&
+        QFileInfo(filePath).size() == 12;
+}
+
+FfmtErrCode Misc_HSC::loadFileInst(QString filePath, FmBank::Instrument &inst, bool *isDrum)
+{
+    Q_UNUSED(isDrum);
+    QFile file(filePath);
+    if(!file.open(QIODevice::ReadOnly))
+        return FfmtErrCode::ERR_NOFILE;
+
+    uint8_t idata[12];
+    if(file.read((char *)idata, 12) != 12)
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    for (int op = 0; op < 2; ++op) {
+        inst.setAVEKM(op, idata[0 + op]);
+        inst.setKSLL(op, idata[2 + op]);
+        inst.setAtDec(op, idata[4 + op]);
+        inst.setSusRel(op, idata[6 + op]);
+        inst.setWaveForm(op, idata[9 + op]);
+    }
+    inst.setFBConn1(idata[8]);
+
+    return FfmtErrCode::ERR_OK;
+}
+
+FfmtErrCode Misc_HSC::saveFileInst(QString filePath, FmBank::Instrument &inst, bool isDrum)
+{
+    Q_UNUSED(isDrum);
+    QFile file(filePath);
+    if(!file.open(QIODevice::WriteOnly))
+        return FfmtErrCode::ERR_NOFILE;
+
+    uint8_t idata[12];
+    for (int op = 0; op < 2; ++op) {
+        idata[0 + op] = inst.getAVEKM(op);
+        idata[2 + op] = inst.getKSLL(op);
+        idata[4 + op] = inst.getAtDec(op);
+        idata[6 + op] = inst.getSusRel(op);
+        idata[9 + op] = inst.getWaveForm(op);
+    }
+    idata[8] = inst.getFBConn1();
+
+    if(file.write((char *)idata, 12) != 12 || !file.flush())
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    return FfmtErrCode::ERR_OK;
+}
+
+int Misc_HSC::formatInstCaps() const
+{
+    return (int)FormatCaps::FORMAT_CAPS_EVERYTHING;
+}
+
+QString Misc_HSC::formatInstName() const
+{
+    return "HSC instrument";
+}
+
+QString Misc_HSC::formatInstExtensionMask() const
+{
+    return "*.ins";
+}
+
+InstFormats Misc_HSC::formatInstId() const
+{
+    return InstFormats::FORMAT_INST_HSC;
+}

--- a/src/FileFormats/format_misc_hsc.h
+++ b/src/FileFormats/format_misc_hsc.h
@@ -1,0 +1,39 @@
+/*
+ * OPL Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2016-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FORMAT_MISC_HSC_H
+#define FORMAT_MISC_HSC_H
+
+#include "ffmt_base.h"
+
+/**
+ * @brief Reader and Writer of the HSC format used by HSC tracker and Adlib Tracker II
+ */
+class Misc_HSC final : public FmBankFormatBase
+{
+public:
+    bool        detectInst(const QString &filePath, char* magic) override;
+    FfmtErrCode loadFileInst(QString filePath, FmBank::Instrument &inst, bool *isDrum = nullptr) override;
+    FfmtErrCode saveFileInst(QString filePath, FmBank::Instrument &inst, bool isDrum = false) override;
+    int         formatInstCaps() const override;
+    QString     formatInstName() const override;
+    QString     formatInstExtensionMask() const override;
+    InstFormats formatInstId() const override;
+};
+
+#endif // FORMAT_MISC_HSC_H


### PR DESCRIPTION
#131

Support the 12 byte `ins` format HSC.

Samples are present in the `AdlibTracker2` folder as `ins` files. Not all these At2 samples are necessarily HSC.

It's because At2 will do special handling: it will load 3 kinds of `ins`, tried in succession.
(checking registers to be in their valid value domains)
- 12 byte, identical to SBI payload but header-less
- 12 byte, HSC payload
-  more than 12 bytes, "SAT" instrument