### PR TITLE
Serial port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ dist: trusty
 before_install:
  - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
  - sudo apt-get update -qq
- - sudo apt-get install qt5-default qtbase5-dev qt5-qmake qttools5-dev-tools libqt5concurrent5 libqt5test5 qtmultimedia5-dev libqt5multimedia5-plugins libqt5multimediawidgets5 qt5-image-formats-plugins libqt5serialport5-dev libasound2-dev libpulse-dev
+ - sudo apt-get install qt5-default qtbase5-dev qt5-qmake qttools5-dev-tools libqt5concurrent5 libqt5test5 qtmultimedia5-dev libqt5multimedia5-plugins libqt5multimediawidgets5 qt5-image-formats-plugins libqt5serialport5-dev libasound2-dev libpulse-dev libudev-dev
 
 script:
  - qmake CONFIG-=debug CONFIG+=release

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ dist: trusty
 before_install:
  - sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
  - sudo apt-get update -qq
- - sudo apt-get install qt5-default qtbase5-dev qt5-qmake qttools5-dev-tools libqt5concurrent5 libqt5test5 qtmultimedia5-dev libqt5multimedia5-plugins libqt5multimediawidgets5 qt5-image-formats-plugins libasound2-dev libpulse-dev
+ - sudo apt-get install qt5-default qtbase5-dev qt5-qmake qttools5-dev-tools libqt5concurrent5 libqt5test5 qtmultimedia5-dev libqt5multimedia5-plugins libqt5multimediawidgets5 qt5-image-formats-plugins libqt5serialport5-dev libasound2-dev libpulse-dev
 
 script:
  - qmake CONFIG-=debug CONFIG+=release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ include(FindPkgConfig)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Concurrent REQUIRED)
 find_package(Qt5LinguistTools REQUIRED)
+find_package(Qt5SerialPort)
 set(QWT_NAMES qwt-qt5 qwt) # find versions for Qt5 only
 find_package(Qwt)
 find_package(ZLIB REQUIRED)
@@ -37,6 +38,12 @@ if(QWT_FOUND)
   set(ENABLE_PLOTS ON)
 else()
   set(ENABLE_PLOTS OFF)
+endif()
+
+if(TARGET Qt5::SerialPort)
+  set(ENABLE_SERIAL_PORT ON)
+else()
+  set(ENABLE_SERIAL_PORT OFF)
 endif()
 
 message("!! Optional feature summary:")
@@ -57,6 +64,8 @@ if(ENABLE_PLOTS)
 endif()
 
 message("!!   Plots: ${ENABLE_PLOTS}")
+
+message("!!   Serial port: ${ENABLE_SERIAL_PORT}")
 
 include_directories("src")
 
@@ -116,6 +125,9 @@ set(CHIPS_SOURCES
 if(ENABLE_OPL3_PROXY)
   list(APPEND CHIPS_SOURCES "src/opl/chips/win9x_opl_proxy.cpp")
 endif()
+if(ENABLE_SERIAL_PORT)
+  list(APPEND CHIPS_SOURCES "src/opl/chips/opl_serial_port.cpp")
+endif()
 add_library(Chips STATIC ${CHIPS_SOURCES})
 target_include_directories(Chips PUBLIC "src")
 if(ENABLE_OPL3_PROXY)
@@ -124,6 +136,10 @@ if(ENABLE_OPL3_PROXY)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(Chips PUBLIC dl)
   endif()
+endif()
+if(ENABLE_SERIAL_PORT)
+  target_link_libraries(Chips PUBLIC Qt5::SerialPort)
+  target_compile_definitions(Chips PUBLIC "-DENABLE_HW_OPL_SERIAL_PORT")
 endif()
 
 set(MEASURER_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,8 @@ set(UIS
   "src/bank_comparison.ui"
   "src/formats_sup.ui"
   "src/importer.ui"
-  "src/audio_config.ui")
+  "src/audio_config.ui"
+  "src/hardware.ui")
 if(ENABLE_PLOTS)
   list(APPEND UIS
     "src/delay_analysis.ui")

--- a/FMBankEdit.pro
+++ b/FMBankEdit.pro
@@ -220,7 +220,8 @@ FORMS += \
     src/bank_comparison.ui \
     src/formats_sup.ui \
     src/importer.ui \
-    src/audio_config.ui
+    src/audio_config.ui \
+    src/hardware.ui
 
 RESOURCES += \
     src/resources/resources.qrc

--- a/FMBankEdit.pro
+++ b/FMBankEdit.pro
@@ -97,6 +97,10 @@ win32||oplproxy: {
     include("src/opl/chips/win9x_opl_proxy.pri")
     DEFINES += ENABLE_HW_OPL_PROXY
 }
+greaterThan(QT_MAJOR_VERSION, 4):{
+    include("src/opl/chips/opl_serial_port.pri")
+    DEFINES += ENABLE_HW_OPL_SERIAL_PORT
+}
 
 win32 {
     lessThan(QT_MAJOR_VERSION, 4):{

--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -41,6 +41,9 @@
 #ifdef ENABLE_HW_OPL_PROXY // to set hardware port
 #include "opl/chips/win9x_opl_proxy.h"
 #endif
+#ifdef ENABLE_HW_OPL_SERIAL_PORT // to set port and rate
+#include "opl/chips/opl_serial_port.h"
+#endif
 
 #include "FileFormats/ffmt_factory.h"
 #include "FileFormats/ffmt_enums.h"
@@ -125,6 +128,7 @@ BankEditor::BankEditor(QWidget *parent) :
     connect(ui->actionEmulatorOpal, SIGNAL(triggered()), this, SLOT(toggleEmulator()));
     connect(ui->actionEmulatorJava, SIGNAL(triggered()), this, SLOT(toggleEmulator()));
     connect(ui->actionWin9xOPLProxy, SIGNAL(triggered()), this, SLOT(toggleEmulator()));
+    connect(ui->actionSerialPortOPL, SIGNAL(triggered()), this, SLOT(toggleEmulator()));
 
 #ifdef ENABLE_HW_OPL_PROXY
     m_proxyOpl = &Generator::oplProxy();
@@ -132,7 +136,13 @@ BankEditor::BankEditor(QWidget *parent) :
     ui->actionWin9xOPLProxy->setVisible(false);
 #endif
 
-#ifndef ENABLE_HW_OPL_PROXY
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+    m_serialPortOpl = &Generator::serialPortOpl();
+#else
+    ui->actionSerialPortOPL->setVisible(false);
+#endif
+
+#if !defined(ENABLE_HW_OPL_PROXY) && !defined(ENABLE_HW_OPL_SERIAL_PORT)
     ui->actionHardware_OPL->setVisible(false);
 #endif
 
@@ -219,6 +229,14 @@ void BankEditor::loadSettings()
     m_proxyOplAddress = setup.value("hw-opl-address", 0x388).toUInt();
     Win9x_OPL_Proxy &proxy = *m_proxyOpl;
     proxy.setOplAddress(m_proxyOplAddress);
+#endif
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+    m_serialPortName = setup.value("hw-opl-serial-port", QString()).toString();
+    m_serialPortBaudRate = setup.value("hw-opl-serial-baud-rate", 115200).toUInt();
+    OPL_SerialPort &serial = *m_serialPortOpl;
+    serial.connectPort(m_serialPortName, m_serialPortBaudRate);
+#endif
+#if defined(ENABLE_HW_OPL_PROXY) || defined(ENABLE_HW_OPL_SERIAL_PORT)
     initChip();
 #endif
 
@@ -232,6 +250,7 @@ void BankEditor::loadSettings()
     ui->actionEmulatorOpal->setChecked(false);
     ui->actionEmulatorJava->setChecked(false);
     ui->actionWin9xOPLProxy->setChecked(false);
+    ui->actionSerialPortOPL->setChecked(false);
 
     switch(m_currentChip)
     {
@@ -251,6 +270,9 @@ void BankEditor::loadSettings()
     case Generator::CHIP_Win9xProxy:
         ui->actionWin9xOPLProxy->setChecked(true);
         break;
+    case Generator::CHIP_SerialPort:
+        ui->actionSerialPortOPL->setChecked(true);
+        break;
     }
 }
 
@@ -266,6 +288,10 @@ void BankEditor::saveSettings()
     setup.setValue("audio-device", m_audioDevice);
 #ifdef ENABLE_HW_OPL_PROXY
     setup.setValue("hw-opl-address", m_proxyOplAddress);
+#endif
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+    setup.setValue("hw-opl-serial-port", m_serialPortName);
+    setup.setValue("hw-opl-serial-baud-rate", m_serialPortBaudRate);
 #endif
 }
 
@@ -1056,6 +1082,7 @@ void BankEditor::toggleEmulator()
     ui->actionEmulatorOpal->setChecked(false);
     ui->actionEmulatorJava->setChecked(false);
     ui->actionWin9xOPLProxy->setChecked(false);
+    ui->actionSerialPortOPL->setChecked(false);
 
     if(menuItem == ui->actionEmulatorNuked)
     {
@@ -1089,6 +1116,13 @@ void BankEditor::toggleEmulator()
     {
         ui->actionWin9xOPLProxy->setChecked(true);
         m_currentChip = Generator::CHIP_Win9xProxy;
+        m_generator->ctl_switchChip(m_currentChip);
+    }
+    else
+    if(menuItem == ui->actionSerialPortOPL)
+    {
+        ui->actionSerialPortOPL->setChecked(true);
+        m_currentChip = Generator::CHIP_SerialPort;
         m_generator->ctl_switchChip(m_currentChip);
     }
 }
@@ -1372,17 +1406,33 @@ void BankEditor::on_actionAudioConfig_triggered()
     }
 }
 
-#ifdef ENABLE_HW_OPL_PROXY
+#if defined(ENABLE_HW_OPL_PROXY) || defined(ENABLE_HW_OPL_SERIAL_PORT)
 void BankEditor::on_actionHardware_OPL_triggered()
 {
+    HardwareDialog *dlg = new HardwareDialog;
+
+#if defined(ENABLE_HW_OPL_PROXY)
     Win9x_OPL_Proxy &proxy = *m_proxyOpl;
     bool supportsChangeAddress = proxy.canSetOplAddress();
-
-    HardwareDialog *dlg = new HardwareDialog;
     dlg->setOplAddress(m_proxyOplAddress);
     dlg->setCanChangeOplAddress(supportsChangeAddress);
+#else
+    dlg->setSoundCardOptionsVisible(false);
+#endif
+
+#if defined(ENABLE_HW_OPL_SERIAL_PORT)
+    OPL_SerialPort &serial = *m_serialPortOpl;
+    dlg->setSerialPortName(m_serialPortName);
+    dlg->setSerialBaudRate(m_serialPortBaudRate);
+#else
+    dlg->setSerialPortOptionsVisible(false);
+#endif
+
     dlg->exec();
 
+    bool mustReinitialize = false;
+
+#if defined(ENABLE_HW_OPL_PROXY)
     if(supportsChangeAddress)
     {
         unsigned newAddress = dlg->oplAddress();
@@ -1390,9 +1440,22 @@ void BankEditor::on_actionHardware_OPL_triggered()
         {
             proxy.setOplAddress(newAddress);
             m_proxyOplAddress = newAddress;
-            initChip();
-            sendPatch();
+            mustReinitialize = true;
         }
+    }
+#endif
+
+#if defined(ENABLE_HW_OPL_SERIAL_PORT)
+    m_serialPortName = dlg->serialPortName();
+    m_serialPortBaudRate = dlg->serialBaudRate();
+    serial.connectPort(m_serialPortName, m_serialPortBaudRate);
+    mustReinitialize = true;
+#endif
+
+    if(mustReinitialize)
+    {
+        initChip();
+        sendPatch();
     }
 
     delete dlg;

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -130,6 +130,12 @@ private:
     unsigned m_proxyOplAddress = 0x388;
 #endif
 
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+    OPL_SerialPort *m_serialPortOpl = nullptr;
+    QString m_serialPortName;
+    unsigned m_serialPortBaudRate = 115200;
+#endif
+
     /*!
      * \brief Initializes audio subsystem and FM generator
      */
@@ -485,7 +491,7 @@ private slots:
      * @brief Opens the audio configuration dialog
      */
     void on_actionAudioConfig_triggered();
-#ifdef ENABLE_HW_OPL_PROXY
+#if defined(ENABLE_HW_OPL_PROXY) || defined(ENABLE_HW_OPL_SERIAL_PORT)
     /**
      * @brief Opens the hardware OPL dialog
      */

--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -3561,6 +3561,7 @@ of second voice</string>
      <addaction name="actionEmulatorOpal"/>
      <addaction name="actionEmulatorJava"/>
      <addaction name="actionWin9xOPLProxy"/>
+     <addaction name="actionSerialPortOPL"/>
     </widget>
     <addaction name="menuChoose_chip_emulator"/>
     <addaction name="actionAudioConfig"/>
@@ -3840,6 +3841,14 @@ of second voice</string>
   <action name="actionCompareWith">
    <property name="text">
     <string>Compare with other bank...</string>
+   </property>
+  </action>
+  <action name="actionSerialPortOPL">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Serial port OPL interface</string>
    </property>
   </action>
  </widget>

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -86,7 +86,7 @@ void HardwareDialog::setSerialPortName(const QString &name) const
 unsigned HardwareDialog::serialBaudRate() const
 {
     Ui::HardwareDialog &ui = *m_ui;
-    return ui.serialRateChoice->currentData().toUInt();
+    return ui.serialRateChoice->itemData(ui.serialRateChoice->currentIndex()).toUInt();
 }
 
 void HardwareDialog::setSerialBaudRate(unsigned rate)

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -18,14 +18,10 @@
 
 #include "hardware.h"
 #include "bank_editor.h"
-#include <QHBoxLayout>
-#include <QVBoxLayout>
-#include <QLineEdit>
-#include <QLabel>
-#include <QDialogButtonBox>
+#include "ui_hardware.h"
 
 HardwareDialog::HardwareDialog(QWidget *parent)
-    : QDialog(parent)
+    : QDialog(parent), m_ui(new Ui::HardwareDialog)
 {
     setupUi();
 }
@@ -36,56 +32,38 @@ HardwareDialog::~HardwareDialog()
 
 unsigned HardwareDialog::oplAddress() const
 {
-    return m_ctlAddressEdit->text().toUInt(nullptr, 16);
+    Ui::HardwareDialog &ui = *m_ui;
+    return ui.ctlAddressEdit->text().toUInt(nullptr, 16);
 }
 
 void HardwareDialog::setOplAddress(unsigned address)
 {
-    m_ctlAddressEdit->setText(QString::number(address, 16));
+    Ui::HardwareDialog &ui = *m_ui;
+    ui.ctlAddressEdit->setText(QString::number(address, 16));
 }
 
 void HardwareDialog::setCanChangeOplAddress(bool can)
 {
-    m_ctlAddressEdit->setEnabled(can);
+    Ui::HardwareDialog &ui = *m_ui;
+    ui.ctlAddressEdit->setEnabled(can);
     updateInfoLabel();
 }
 
 void HardwareDialog::setupUi()
 {
-    setWindowTitle(tr("Hardware OPL"));
-
-    QVBoxLayout *vl = new QVBoxLayout;
-    setLayout(vl);
-
-    vl->addWidget(new QLabel(tr("Define the hardware address.")));
-
-    QLabel *infoLabel = m_infoLabel = new QLabel;
-    vl->addWidget(infoLabel);
+    Ui::HardwareDialog &ui = *m_ui;
+    ui.setupUi(this);
     updateInfoLabel();
-
-    QHBoxLayout *ctlBox = new QHBoxLayout;
-    vl->addLayout(ctlBox);
-
-    ctlBox->addWidget(new QLabel(tr("Hexadecimal address: ")));
-
-    QLineEdit *ctlAddressEdit = m_ctlAddressEdit = new QLineEdit;
-    ctlBox->addWidget(ctlAddressEdit);
-    ctlAddressEdit->setInputMask("hhhh");
-
-    QDialogButtonBox *bbox = new QDialogButtonBox(QDialogButtonBox::Ok);
-    vl->addWidget(bbox);
-    connect(bbox, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(bbox, SIGNAL(rejected()), this, SLOT(reject()));
-
     adjustSize();
     setFixedSize(size());
 }
 
 void HardwareDialog::updateInfoLabel()
 {
-    if(m_ctlAddressEdit && m_ctlAddressEdit->isEnabled())
-        m_infoLabel->setText(tr("Usually $388, varies depending on card."));
+    Ui::HardwareDialog &ui = *m_ui;
+    if(ui.ctlAddressEdit && ui.ctlAddressEdit->isEnabled())
+        ui.infoLabel->setText(tr("Usually $388, varies depending on card."));
     else
-        m_infoLabel->setText(tr("Impossible to set the hardware address.\n"
-                                "Make sure you installed the latest OPL proxy."));
+        ui.infoLabel->setText(tr("Impossible to set the hardware address.\n"
+                                 "Make sure you installed the latest OPL proxy."));
 }

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -20,8 +20,9 @@
 #define HARDWARE_H
 
 #include <QDialog>
-class QLineEdit;
-class QLabel;
+#include <memory>
+
+namespace Ui { class HardwareDialog; }
 
 class HardwareDialog : public QDialog
 {
@@ -38,8 +39,8 @@ public:
 private:
     void setupUi();
     void updateInfoLabel();
-    QLabel *m_infoLabel = nullptr;
-    QLineEdit *m_ctlAddressEdit = nullptr;
+
+    std::unique_ptr<Ui::HardwareDialog> m_ui;
 };
 
 #endif // HARDWARE_H

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -32,15 +32,28 @@ public:
     HardwareDialog(QWidget *parent = nullptr);
     ~HardwareDialog();
 
+    void setSoundCardOptionsVisible(bool visible);
+    void setSerialPortOptionsVisible(bool visible);
+
     unsigned oplAddress() const;
     void setOplAddress(unsigned address);
     void setCanChangeOplAddress(bool can);
+
+    QString serialPortName() const;
+    void setSerialPortName(const QString &name) const;
+    unsigned serialBaudRate() const;
+    void setSerialBaudRate(unsigned rate);
+
+public slots:
+    void on_serialPortButton_triggered(QAction *);
+    void onSerialPortChosen();
 
 private:
     void setupUi();
     void updateInfoLabel();
 
     std::unique_ptr<Ui::HardwareDialog> m_ui;
+    QAction *m_serialPortAction = nullptr;
 };
 
 #endif // HARDWARE_H

--- a/src/hardware.ui
+++ b/src/hardware.ui
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>HardwareDialog</class>
+ <widget class="QDialog" name="HardwareDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>277</width>
+    <height>151</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Hardware OPL</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Sound card</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Define the hardware address.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="infoLabel">
+        <property name="text">
+         <string notr="true">&lt;&lt;Info&gt;&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Hexadecimal address:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="ctlAddressEdit">
+          <property name="inputMask">
+           <string>hhhh</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>HardwareDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>HardwareDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/hardware.ui
+++ b/src/hardware.ui
@@ -7,15 +7,15 @@
     <x>0</x>
     <y>0</y>
     <width>277</width>
-    <height>151</height>
+    <height>278</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Hardware OPL</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="soundCardGroup">
      <property name="title">
       <string>Sound card</string>
      </property>
@@ -56,6 +56,74 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="serialPortGroup">
+     <property name="title">
+      <string>Serial port</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Select the serial port.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Port:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLineEdit" name="serialPortEdit"/>
+          </item>
+          <item>
+           <widget class="QToolButton" name="serialPortButton">
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="resources/resources.qrc">
+              <normaloff>:/mporto.png</normaloff>:/mporto.png</iconset>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Baud rate:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="serialRateChoice"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -67,7 +135,9 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="resources/resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/src/opl/chips/opl_serial_port.cpp
+++ b/src/opl/chips/opl_serial_port.cpp
@@ -1,0 +1,77 @@
+/*
+ * OPL Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2016-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "opl_serial_port.h"
+
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+
+#include <QSerialPort>
+
+OPL_SerialPort::OPL_SerialPort()
+    : m_port(nullptr)
+{
+}
+
+OPL_SerialPort::~OPL_SerialPort()
+{
+    delete m_port;
+    m_port = nullptr;
+}
+
+bool OPL_SerialPort::connectPort(const QString &name, unsigned baudRate)
+{
+    delete m_port;
+    m_port = nullptr;
+
+    QSerialPort *port = m_port = new QSerialPort(name);
+    port->setBaudRate(baudRate);
+    return port->open(QSerialPort::WriteOnly);
+}
+
+void OPL_SerialPort::writeReg(uint16_t addr, uint8_t data)
+{
+    QSerialPort *port = m_port;
+    if(!port || !port->isOpen())
+        return;
+
+    // TODO support OPL2 only
+    if(addr >= 0x100)
+        return;
+
+    uint8_t sendBuffer[2] = {(uint8_t)addr, data};
+    port->write((char *)sendBuffer, 2);
+}
+
+void OPL_SerialPort::nativeGenerate(int16_t *frame)
+{
+    frame[0] = 0;
+    frame[1] = 0;
+}
+
+const char *OPL_SerialPort::emulatorName()
+{
+    return "OPL Serial Port Driver";
+}
+
+OPLChipBase::ChipType OPL_SerialPort::chipType()
+{
+    // TODO support OPL2 only
+    return OPLChipBase::CHIPTYPE_OPL2;
+}
+
+#endif // ENABLE_HW_OPL_SERIAL_PORT

--- a/src/opl/chips/opl_serial_port.h
+++ b/src/opl/chips/opl_serial_port.h
@@ -1,0 +1,54 @@
+/*
+ * OPL Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2016-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPL_SERIAL_PORT_H
+#define OPL_SERIAL_PORT_H
+
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+
+#include "opl_chip_base.h"
+
+class QSerialPort;
+class QString;
+
+///
+class OPL_SerialPort : public OPLChipBaseT<OPL_SerialPort>
+{
+public:
+    OPL_SerialPort();
+    ~OPL_SerialPort() override;
+
+    bool connectPort(const QString &name, unsigned baudRate);
+
+    bool canRunAtPcmRate() const override { return false; }
+    void setRate(uint32_t /*rate*/) override {}
+    void reset() override {}
+    void writeReg(uint16_t addr, uint8_t data) override;
+    void nativePreGenerate() override {}
+    void nativePostGenerate() override {}
+    void nativeGenerate(int16_t *frame) override;
+    const char *emulatorName() override;
+    ChipType chipType() override;
+
+private:
+    QSerialPort *m_port;
+};
+
+#endif // ENABLE_HW_OPL_SERIAL_PORT
+
+#endif // OPL_SERIAL_PORT_H

--- a/src/opl/chips/opl_serial_port.pri
+++ b/src/opl/chips/opl_serial_port.pri
@@ -1,0 +1,4 @@
+QT += serialport
+
+HEADERS += $$PWD/opl_serial_port.h
+SOURCES += $$PWD/opl_serial_port.cpp

--- a/src/opl/generator.cpp
+++ b/src/opl/generator.cpp
@@ -30,6 +30,10 @@
 #include "chips/win9x_opl_proxy.h"
 #endif
 
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+#include "chips/opl_serial_port.h"
+#endif
+
 #define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
 #define BYTE_TO_BINARY(byte)  \
       (byte & 0x80 ? '1' : '0'), \
@@ -240,6 +244,10 @@ void Generator::OPLChipDelete::operator()(OPLChipBase *x)
     if(x == &Generator::oplProxy())
         return;
 #endif
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+    if(x == &Generator::serialPortOpl())
+        return;
+#endif
     delete x;
 }
 
@@ -296,15 +304,28 @@ Win9x_OPL_Proxy &Generator::oplProxy()
 }
 #endif
 
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+OPL_SerialPort &Generator::serialPortOpl()
+{
+    static OPL_SerialPort serial;
+    return serial;
+}
+#endif
+
 void Generator::switchChip(Generator::OPL_Chips chipId)
 {
     switch(chipId)
     {
-    case CHIP_Win9xProxy:
 #ifdef ENABLE_HW_OPL_PROXY
+    case CHIP_Win9xProxy:
         chip.reset(&oplProxy());
-#endif
         break;
+#endif
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+    case CHIP_SerialPort:
+        chip.reset(&serialPortOpl());
+        break;
+#endif
     case CHIP_DosBox:
         chip.reset(new DosBoxOPL3());
         break;

--- a/src/opl/generator.h
+++ b/src/opl/generator.h
@@ -31,6 +31,10 @@
 class Win9x_OPL_Proxy;
 #endif
 
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+class OPL_SerialPort;
+#endif
+
 #define NUM_OF_CHANNELS         23
 #define MAX_OPLGEN_BUFFER_SIZE  4096
 
@@ -85,6 +89,7 @@ public:
         CHIP_Opal,
         CHIP_Java,
         CHIP_Win9xProxy,
+        CHIP_SerialPort,
         CHIP_END
     };
     Generator(uint32_t sampleRate, OPL_Chips initialChip);
@@ -163,6 +168,10 @@ public:
 
 #ifdef ENABLE_HW_OPL_PROXY
     static Win9x_OPL_Proxy &oplProxy();
+#endif
+
+#ifdef ENABLE_HW_OPL_SERIAL_PORT
+    static OPL_SerialPort &serialPortOpl();
 #endif
 
 private:


### PR DESCRIPTION
#153
an attempt at OPL2 parallel port support.

I divided the hardware configuration dialog into 2 subgroups : for opl proxy, and serial port.
The groups which are not supported are hidden in runtime.

Since it's converted to a qt designer form, translations need an update of some existing strings + new ones.

note: QSerialPort is supported in Qt5 only.
It needs `ENABLE_HW_OPL_SERIAL_PORT` to enable it under the chips directory.

There is also a setting which stores the port name and the baud rate.

For testing. (cc @DhrBaksteen @Deftaudio)