### PR TITLE
hardware: add a setting to choose the serial protocol

### DIFF
--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -242,8 +242,9 @@ void BankEditor::loadSettings()
 #ifdef ENABLE_HW_OPL_SERIAL_PORT
     m_serialPortName = setup.value("hw-opl-serial-port", QString()).toString();
     m_serialPortBaudRate = setup.value("hw-opl-serial-baud-rate", 115200).toUInt();
+    m_serialPortProtocol = setup.value("hw-opl-serial-protocol", 0u).toUInt();
     OPL_SerialPort &serial = *m_serialPortOpl;
-    serial.connectPort(m_serialPortName, m_serialPortBaudRate);
+    serial.connectPort(m_serialPortName, m_serialPortBaudRate, m_serialPortProtocol);
 #endif
 #if defined(ENABLE_HW_OPL_PROXY) || defined(ENABLE_HW_OPL_SERIAL_PORT)
     initChip();
@@ -301,6 +302,7 @@ void BankEditor::saveSettings()
 #ifdef ENABLE_HW_OPL_SERIAL_PORT
     setup.setValue("hw-opl-serial-port", m_serialPortName);
     setup.setValue("hw-opl-serial-baud-rate", m_serialPortBaudRate);
+    setup.setValue("hw-opl-serial-protocol", m_serialPortProtocol);
 #endif
 }
 
@@ -1394,6 +1396,7 @@ void BankEditor::on_actionHardware_OPL_triggered()
     OPL_SerialPort &serial = *m_serialPortOpl;
     dlg->setSerialPortName(m_serialPortName);
     dlg->setSerialBaudRate(m_serialPortBaudRate);
+    dlg->setSerialProtocol(m_serialPortProtocol);
 #else
     dlg->setSerialPortOptionsVisible(false);
 #endif
@@ -1418,7 +1421,8 @@ void BankEditor::on_actionHardware_OPL_triggered()
 #if defined(ENABLE_HW_OPL_SERIAL_PORT)
     m_serialPortName = dlg->serialPortName();
     m_serialPortBaudRate = dlg->serialBaudRate();
-    serial.connectPort(m_serialPortName, m_serialPortBaudRate);
+    m_serialPortProtocol = dlg->serialProtocol();
+    serial.connectPort(m_serialPortName, m_serialPortBaudRate, m_serialPortProtocol);
     mustReinitialize = true;
 #endif
 

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -134,6 +134,7 @@ private:
     OPL_SerialPort *m_serialPortOpl = nullptr;
     QString m_serialPortName;
     unsigned m_serialPortBaudRate = 115200;
+    unsigned m_serialPortProtocol = 0;
 #endif
 
     /*!

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -23,6 +23,7 @@
 #include <QAction>
 #include <QDebug>
 #ifdef ENABLE_HW_OPL_SERIAL_PORT
+#include "opl/chips/opl_serial_port.h"
 #include <QSerialPortInfo>
 #endif
 
@@ -95,6 +96,18 @@ void HardwareDialog::setSerialBaudRate(unsigned rate)
     ui.serialRateChoice->setCurrentIndex(ui.serialRateChoice->findData(rate));
 }
 
+unsigned HardwareDialog::serialProtocol() const
+{
+    Ui::HardwareDialog &ui = *m_ui;
+    return ui.serialProtocolChoice->itemData(ui.serialProtocolChoice->currentIndex()).toUInt();
+}
+
+void HardwareDialog::setSerialProtocol(unsigned protocol)
+{
+    Ui::HardwareDialog &ui = *m_ui;
+    ui.serialProtocolChoice->setCurrentIndex(ui.serialProtocolChoice->findData(protocol));
+}
+
 void HardwareDialog::on_serialPortButton_triggered(QAction *)
 {
     Ui::HardwareDialog &ui = *m_ui;
@@ -135,6 +148,9 @@ void HardwareDialog::setupUi()
         if (rate >= 1200 && rate <= 115200)
             ui.serialRateChoice->addItem(QString::number(rate), rate);
     }
+
+    ui.serialProtocolChoice->addItem(
+        tr("Arduino OPL2"), (unsigned)OPL_SerialPort::ProtocolArduinoOPL2);
 
     QAction *serialPortAction = m_serialPortAction = new QAction(
         ui.serialPortButton->icon(), ui.serialPortButton->text(), this);

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -151,6 +151,8 @@ void HardwareDialog::setupUi()
 
     ui.serialProtocolChoice->addItem(
         tr("Arduino OPL2"), (unsigned)OPL_SerialPort::ProtocolArduinoOPL2);
+    ui.serialProtocolChoice->addItem(
+        tr("Nuke.YKT OPL3"), (unsigned)OPL_SerialPort::ProtocolNukeYktOPL3);
 
     QAction *serialPortAction = m_serialPortAction = new QAction(
         ui.serialPortButton->icon(), ui.serialPortButton->text(), this);

--- a/src/hardware.h
+++ b/src/hardware.h
@@ -43,6 +43,8 @@ public:
     void setSerialPortName(const QString &name) const;
     unsigned serialBaudRate() const;
     void setSerialBaudRate(unsigned rate);
+    unsigned serialProtocol() const;
+    void setSerialProtocol(unsigned protocol);
 
 public slots:
     void on_serialPortButton_triggered(QAction *);

--- a/src/hardware.ui
+++ b/src/hardware.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>277</width>
-    <height>288</height>
+    <height>307</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -108,6 +108,16 @@
         </item>
         <item row="1" column="1">
          <widget class="QComboBox" name="serialRateChoice"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Protocol:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="serialProtocolChoice"/>
         </item>
        </layout>
       </item>

--- a/src/opl/chips/opl_serial_port.h
+++ b/src/opl/chips/opl_serial_port.h
@@ -22,8 +22,9 @@
 #ifdef ENABLE_HW_OPL_SERIAL_PORT
 
 #include "opl_chip_base.h"
-#include <QString>
 #include <QObject>
+#include <QString>
+#include <QAtomicInt>
 
 class QSerialPort;
 
@@ -36,7 +37,13 @@ public:
     OPL_SerialPort();
     ~OPL_SerialPort() override;
 
-    bool connectPort(const QString &name, unsigned baudRate);
+    enum Protocol
+    {
+        ProtocolUnknown,
+        ProtocolArduinoOPL2,
+    };
+
+    bool connectPort(const QString &name, unsigned baudRate, unsigned protocol);
 
     bool canRunAtPcmRate() const override { return false; }
     void setRate(uint32_t /*rate*/) override {}
@@ -53,6 +60,7 @@ private slots:
 
 private:
     QSerialPort *m_port;
+    QAtomicInt m_protocol;
 };
 
 #endif // ENABLE_HW_OPL_SERIAL_PORT

--- a/src/opl/chips/opl_serial_port.h
+++ b/src/opl/chips/opl_serial_port.h
@@ -41,6 +41,7 @@ public:
     {
         ProtocolUnknown,
         ProtocolArduinoOPL2,
+        ProtocolNukeYktOPL3,
     };
 
     bool connectPort(const QString &name, unsigned baudRate, unsigned protocol);


### PR DESCRIPTION
#153

I add the drop-down menu which permits to choose "Arduino OPL2" as a selection of serial protocol.
Adding future protocols should take minimal effort from here.